### PR TITLE
Fixed two errors that occur after a clean install

### DIFF
--- a/subdaap/cache.py
+++ b/subdaap/cache.py
@@ -179,7 +179,7 @@ class FileCache(object):
         with cache_item.lock:
             if cache_item.iterator is None:
                 cache_item.ready.clear()
-                self.load(cache_key)
+                self.load(cache_key, cache_item)
 
         return cache_item
 

--- a/subdaap/database.py
+++ b/subdaap/database.py
@@ -148,6 +148,7 @@ class Database(object):
                         `id` INTEGER PRIMARY KEY,
                         `persistent_id` INTEGER DEFAULT 0,
                         `database_id` int(11) NOT NULL,
+                        `container_id` int(11) NOT NULL,
                         `item_id` int(11) NOT NULL,
                         `order` int(11) DEFAULT NULL,
                         CONSTRAINT `container_item_fk_1` FOREIGN KEY (`database_id`) REFERENCES `databases` (`id`)

--- a/subdaap/state.py
+++ b/subdaap/state.py
@@ -32,10 +32,10 @@ class State(object):
         Save state to file.
         """
 
-        logger.debug("Saving application state to '%s'.", self.state_file)
+        logger.debug("Saving application state to '%s'.", self.file_name)
 
         with self.lock:
-            with open(self.state_file, "wb") as fp:
+            with open(self.file_name, "wb") as fp:
                 cPickle.dump(self.state, fp)
 
     def load(self):


### PR DESCRIPTION
I ran into two problems:
- variable had been renamed (`file_name`) but old name was still used
- cache call (when switching to a song that is still downloading)
  caused an error due to incorrect parameters

I guess you can not avoid this without integration tests. I hope that my changes do not cause additional errors...
