### PR TITLE
Return the correct file size for a transcoded file

### DIFF
--- a/subdaap/connection.py
+++ b/subdaap/connection.py
@@ -92,8 +92,8 @@ class Connection(object):
             logger.debug(
                 "Transcoding item '%d' with file suffix '%s'.",
                 remote_id, file_suffix)
-            return self.subsonic.stream(
-                remote_id, tformat="mp3")
+            return self.subsonic.stream(remote_id, tformat="mp3",
+                                        estimateContentLength=True)
         else:
             return self.subsonic.download(remote_id)
 

--- a/subdaap/provider.py
+++ b/subdaap/provider.py
@@ -76,7 +76,11 @@ class Provider(provider.Provider):
             self.cache_manager.item_cache.download(
                 item.id, cache_item, remote_fd)
 
+            real_file_size = remote_fd.headers.get('content-length',
+                                                   item.file_size)
+            print("real size: {}".format(real_file_size))
+
             return cache_item.iterator(byte_range), item.file_type, \
-                item.file_size
+                real_file_size
         return cache_item.iterator(byte_range), item.file_type, \
             cache_item.size

--- a/subdaap/provider.py
+++ b/subdaap/provider.py
@@ -76,6 +76,9 @@ class Provider(provider.Provider):
             self.cache_manager.item_cache.download(
                 item.id, cache_item, remote_fd)
 
+            # When a file is being transcoded, the real size is much smaller
+            # than the source file size that is stored in the item's metadata.
+            # -> return the file size estimated by subsonic from the headers.
             real_file_size = remote_fd.headers.get('content-length',
                                                    item.file_size)
             print("real size: {}".format(real_file_size))


### PR DESCRIPTION
Before this patch, the size of a transcoded file was returned as the
size of the raw file. In the case of at least one file format (FLAC) the
raw file is much  larger than the transcoded response.

With this path, subdaap requests the estimated content size from
subsonic. This size is then used in the response that is returned to the
client while streaming.
#### Result

The duration for a transcoded, streaming file is shown correctly in iTunes. Since the length is correct, it is now possible to skip in these files (after caching is complete).
