### PR TITLE
Feature/sync various artist album artist

### DIFF
--- a/subdaap/database.py
+++ b/subdaap/database.py
@@ -203,7 +203,11 @@ class Cursor(sqlite3.Cursor):
         result = dict()
 
         for row in self.execute(query, args):
-            result[int(row[0])] = dict(row)
+            row_d = dict(row)
+            try:
+                result[int(row[0])] = row_d
+            except ValueError:
+                result[row[0]] = row_d
 
         return result
 

--- a/subdaap/database.py
+++ b/subdaap/database.py
@@ -203,7 +203,7 @@ class Cursor(sqlite3.Cursor):
         result = dict()
 
         for row in self.execute(query, args):
-            result[row[0]] = dict(row)
+            result[int(row[0])] = dict(row)
 
         return result
 

--- a/subdaap/synchronizer.py
+++ b/subdaap/synchronizer.py
@@ -413,8 +413,8 @@ class Synchronizer(object):
                 "updated" in self.synthetic_artists_by_name[item["artist"]]
 
         def is_album_processed(album):
-            return album["artistId"] in self.albums_by_remote_id and  \
-                "updated" in self.albums_by_remote_id[album["artistId"]]
+            return album["id"] in self.albums_by_remote_id and  \
+                "updated" in self.albums_by_remote_id[album["id"]]
 
         def removed_ids(items):
             for value in items.itervalues():
@@ -474,13 +474,17 @@ class Synchronizer(object):
             if "artistId" in item:
                 if not is_artist_processed(item):
                     self.sync_artist(item)
-
-                    for album in self.subsonic.walk_artist(item["artistId"]):
-                        if not is_album_processed(album):
-                            self.sync_album(album)
             elif "artist" in item:
                 if not is_synthetic_artist_processed(item):
                     self.sync_synthetic_artist(item)
+
+            album = self.subsonic.getAlbum(item["albumId"]).get('album', None)
+            if album and not is_album_processed(album):
+                if "artistId" in album:
+                    if not is_artist_processed(album):
+                        self.sync_artist(album)
+
+                self.sync_album(album)
 
             self.sync_item(item)
             self.sync_base_container_item(item)

--- a/subdaap/synchronizer.py
+++ b/subdaap/synchronizer.py
@@ -412,9 +412,9 @@ class Synchronizer(object):
             return item["artist"] in self.synthetic_artists_by_name and \
                 "updated" in self.synthetic_artists_by_name[item["artist"]]
 
-        def is_album_processed(album):
-            return album["id"] in self.albums_by_remote_id and  \
-                "updated" in self.albums_by_remote_id[album["id"]]
+        def is_album_processed(album_id):
+            return album_id in self.albums_by_remote_id and  \
+                "updated" in self.albums_by_remote_id[album_id]
 
         def removed_ids(items):
             for value in items.itervalues():
@@ -478,8 +478,8 @@ class Synchronizer(object):
                 if not is_synthetic_artist_processed(item):
                     self.sync_synthetic_artist(item)
 
-            album = self.subsonic.getAlbum(item["albumId"]).get('album', None)
-            if album and not is_album_processed(album):
+            if not is_album_processed(item["albumId"]):
+                album = self.subsonic.getAlbum(item["albumId"]).get('album')
                 if "artistId" in album:
                     if not is_artist_processed(album):
                         self.sync_artist(album)


### PR DESCRIPTION
This is another patch that fixes the synchronisation of `various artists` albums.

It has one side-effect:
- database dictionary keys are not interpreted as ints. If the value can not be parsed, the raw value is used.

This change was needed because new (inserted) rows had a integer key, while rows loaded from the database had string keys.
