### PR TITLE
Make the cache pruning interval configurable

### DIFF
--- a/config.ini.default
+++ b/config.ini.default
@@ -99,6 +99,10 @@ item cache size = 10240
 # values will make more space, but may remove too much
 # item cache prune threshold = 0.25
 
+# How often should expired items be searched and pruned (in minutes)?
+# Default: 5 minutes.
+# item cache prune interval = 300
+
 
 [Advanced]
 

--- a/subdaap/application.py
+++ b/subdaap/application.py
@@ -196,12 +196,14 @@ class Application(object):
             _job, max_instances=1, trigger="interval", seconds=1)
 
         # Scheduler task to clean and expire the cache.
+        cache_interval = self.config['Provider']['item cache prune interval']
+
         self.scheduler.add_job(
             self.cache_manager.expire,
-            max_instances=1, trigger="interval", minutes=5)
+            max_instances=1, trigger="interval", minutes=cache_interval)
         self.scheduler.add_job(
             self.cache_manager.clean,
-            max_instances=1, trigger="interval", minutes=30)
+            max_instances=1, trigger="interval", minutes=cache_interval)
 
         # Schedule tasks to synchronize each connection.
         for connection in self.connections.itervalues():

--- a/subdaap/config.py
+++ b/subdaap/config.py
@@ -49,6 +49,7 @@ item cache = boolean(default=True)
 item cache dir = string(default="./items")
 item cache size = integer(min=0, default=0)
 item cache prune threshold = float(min=0, max=1.0, default=0.25)
+item cache prune interval = integer(min=1, default=5)
 
 [Advanced]
 open files limit = integer(min=-1, default=-1)


### PR DESCRIPTION
`is_initial_synced` is an attribute of the `synchroniser`, not of the connection. The call failed with an AttributeError.
